### PR TITLE
Fix conference dates: 25th & 26th May 2027

### DIFF
--- a/404.html
+++ b/404.html
@@ -107,7 +107,7 @@
           <span class="dates">
             Oslo<br />
             Tue &amp; Wed<br />
-            24th &amp; 25th May<br />
+            25th &amp; 26th May<br />
             2027
           </span>
         </div>

--- a/about.html
+++ b/about.html
@@ -106,7 +106,7 @@
           <span class="dates">
             Oslo<br />
             Tue &amp; Wed<br />
-            24th &amp; 25th May<br />
+            25th &amp; 26th May<br />
             2027
           </span>
         </div>

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
           <span class="dates">
             Oslo<br />
             Tue &amp; Wed<br />
-            24th &amp; 25th May<br />
+            25th &amp; 26th May<br />
             2027
           </span>
         </div>
@@ -160,12 +160,12 @@
 
       <section>
         <h1 class="page-title">Web Rebels is back!</h1>
-        <p>After a long break, Web Rebels returns to Oslo on May 24th &amp; 25th 2027. Two days, one track, 16 speakers.</p>
+        <p>After a long break, Web Rebels returns to Oslo on May 25th &amp; 26th 2027. Two days, one track, 16 speakers.</p>
       </section>
 
       <section>
         <h2 class="section-heading">Save the date</h2>
-        <p>Remember to hold of the days 24th and 25th in your calendar for 2027</p>
+        <p>Remember to hold of the days 25th and 26th in your calendar for 2027</p>
       </section>
 
       <section>

--- a/info.html
+++ b/info.html
@@ -107,7 +107,7 @@
           <span class="dates">
             Oslo<br />
             Tue &amp; Wed<br />
-            24th &amp; 25th May<br />
+            25th &amp; 26th May<br />
             2027
           </span>
         </div>

--- a/roadbook.html
+++ b/roadbook.html
@@ -107,7 +107,7 @@
           <span class="dates">
             Oslo<br />
             Tue &amp; Wed<br />
-            24th &amp; 25th May<br />
+            25th &amp; 26th May<br />
             2027
           </span>
         </div>

--- a/schedule.html
+++ b/schedule.html
@@ -107,7 +107,7 @@
           <span class="dates">
             Oslo<br />
             Tue &amp; Wed<br />
-            24th &amp; 25th May<br />
+            25th &amp; 26th May<br />
             2027
           </span>
         </div>

--- a/speakers.html
+++ b/speakers.html
@@ -107,7 +107,7 @@
           <span class="dates">
             Oslo<br />
             Tue &amp; Wed<br />
-            24th &amp; 25th May<br />
+            25th &amp; 26th May<br />
             2027
           </span>
         </div>

--- a/sponsors.html
+++ b/sponsors.html
@@ -107,7 +107,7 @@
           <span class="dates">
             Oslo<br />
             Tue &amp; Wed<br />
-            24th &amp; 25th May<br />
+            25th &amp; 26th May<br />
             2027
           </span>
         </div>

--- a/template.html
+++ b/template.html
@@ -107,7 +107,7 @@
           <span class="dates">
             Oslo<br />
             Tue &amp; Wed<br />
-            24th &amp; 25th May<br />
+            25th &amp; 26th May<br />
             2027
           </span>
         </div>


### PR DESCRIPTION
The site said 24th & 25th May 2027; the correct dates are 25th & 26th May 2027. Updated the footer on all pages and the intro/save-the-date text on the front page.

Fixes #5