### PR TITLE
Add weekdays to front page dates and fix Save the date typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,12 +160,12 @@
 
       <section>
         <h1 class="page-title">Web Rebels is back!</h1>
-        <p>After a long break, Web Rebels returns to Oslo on May 25th &amp; 26th 2027. Two days, one track, 16 speakers.</p>
+        <p>After a long break, Web Rebels returns to Oslo on Tuesday May 25th &amp; Wednesday May 26th 2027. Two days, one track, 16 speakers.</p>
       </section>
 
       <section>
         <h2 class="section-heading">Save the date</h2>
-        <p>Remember to hold of the days 25th and 26th in your calendar for 2027</p>
+        <p>Block out Tuesday May 25th and Wednesday May 26th 2027 in your calendar. Pinky promise it'll be worth it.</p>
       </section>
 
       <section>


### PR DESCRIPTION
Fixes #7

- "Web Rebels is back!" now spells out the weekdays: Tuesday May 25th & Wednesday May 26th 2027.
- Rewrote the "Save the date" sentence, which had a typo ("Remember to hold of the days 25th and 26th in your calendar for 2027"). New copy matches the crew's old newsletter voice: "Block out Tuesday May 25th and Wednesday May 26th 2027 in your calendar. Pinky promise it'll be worth it."